### PR TITLE
quilt: Update go imports to new repo locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Quilt CI
 
-This repository contains a Quilt spec for a Jenkins deployment that tests
-[Quilt](github.com/quilt/quilt).
+This repository contains a Kelda spec for a Jenkins deployment that tests
+[Kelda](github.com/Kelda/Kelda).
 
 It also contains a custom Docker image because we require some build tools and
 Jenkins plugins for our testing job.

--- a/config/jenkins/job.xml
+++ b/config/jenkins/job.xml
@@ -8,7 +8,7 @@
     <configVersion>2</configVersion>
     <userRemoteConfigs>
       <hudson.plugins.git.UserRemoteConfig>
-        <url>https://github.com/quilt/quilt</url>
+        <url>https://github.com/kelda/kelda</url>
       </hudson.plugins.git.UserRemoteConfig>
     </userRemoteConfigs>
     <branches>
@@ -20,7 +20,7 @@
     <submoduleCfg class="list"/>
     <extensions>
       <hudson.plugins.git.extensions.impl.RelativeTargetDirectory>
-        <relativeTargetDir>gohome/src/github.com/quilt/quilt</relativeTargetDir>
+        <relativeTargetDir>gohome/src/github.com/kelda/kelda</relativeTargetDir>
       </hudson.plugins.git.extensions.impl.RelativeTargetDirectory>
     </extensions>
   </scm>
@@ -39,10 +39,10 @@
       <command>export GOPATH=${WORKSPACE}/gohome
 export PATH=${GOPATH}/bin:${PATH}
 
-go install -v github.com/quilt/quilt
-go get -v github.com/quilt/tester
+go install -v github.com/kelda/kelda
+go get -v github.com/kelda/tester
 
-cd $GOPATH/src/github.com/quilt/tester
+cd $GOPATH/src/github.com/kelda/tester
 make tests
 tester --preserve-failed -testRoot=./tests -junitOut=${WORKSPACE}/report.xml</command>
     </hudson.tasks.Shell>

--- a/exec.go
+++ b/exec.go
@@ -13,10 +13,10 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
 
-	"github.com/quilt/quilt/api"
-	"github.com/quilt/quilt/api/client"
-	"github.com/quilt/quilt/db"
-	"github.com/quilt/quilt/util"
+	"github.com/kelda/kelda/api"
+	"github.com/kelda/kelda/api/client"
+	"github.com/kelda/kelda/db"
+	"github.com/kelda/kelda/util"
 )
 
 // runSpecUntilConnected runs the given spec, and blocks until either all

--- a/quilt-tester.go
+++ b/quilt-tester.go
@@ -14,11 +14,11 @@ import (
 
 	"github.com/Sirupsen/logrus"
 
-	"github.com/quilt/quilt/api"
-	"github.com/quilt/quilt/api/client/getter"
-	apiUtil "github.com/quilt/quilt/api/util"
-	"github.com/quilt/quilt/stitch"
-	"github.com/quilt/quilt/util"
+	"github.com/kelda/kelda/api"
+	"github.com/kelda/kelda/api/client/getter"
+	apiUtil "github.com/kelda/kelda/api/util"
+	"github.com/kelda/kelda/stitch"
+	"github.com/kelda/kelda/util"
 )
 
 var (

--- a/tests/10-network/check_network.go
+++ b/tests/10-network/check_network.go
@@ -11,11 +11,11 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 
-	"github.com/quilt/quilt/api"
-	"github.com/quilt/quilt/api/client"
-	"github.com/quilt/quilt/api/client/getter"
-	"github.com/quilt/quilt/db"
-	"github.com/quilt/quilt/join"
+	"github.com/kelda/kelda/api"
+	"github.com/kelda/kelda/api/client"
+	"github.com/kelda/kelda/api/client/getter"
+	"github.com/kelda/kelda/db"
+	"github.com/kelda/kelda/join"
 )
 
 // anyIPAllowed is used to indicate that any non-error response is okay for an external

--- a/tests/100-logs/check_logs.go
+++ b/tests/100-logs/check_logs.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/quilt/quilt/api"
-	"github.com/quilt/quilt/api/client/getter"
+	"github.com/kelda/kelda/api"
+	"github.com/kelda/kelda/api/client/getter"
 )
 
 var machineRegex = regexp.MustCompile(`Machine-(\d+){(.+?), .*, PublicIP=(.*?),`)

--- a/tests/15-bandwidth/check_bandwidth.go
+++ b/tests/15-bandwidth/check_bandwidth.go
@@ -11,9 +11,9 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 
-	"github.com/quilt/quilt/api"
-	"github.com/quilt/quilt/api/client/getter"
-	"github.com/quilt/quilt/db"
+	"github.com/kelda/kelda/api"
+	"github.com/kelda/kelda/api/client/getter"
+	"github.com/kelda/kelda/db"
 )
 
 // The required bandwidth in Mb/s between two containers on different machines.

--- a/tests/20-spark/check_spark.go
+++ b/tests/20-spark/check_spark.go
@@ -7,8 +7,8 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 
-	"github.com/quilt/quilt/api"
-	"github.com/quilt/quilt/api/client/getter"
+	"github.com/kelda/kelda/api"
+	"github.com/kelda/kelda/api/client/getter"
 )
 
 func main() {

--- a/tests/30-mean/check_mean.go
+++ b/tests/30-mean/check_mean.go
@@ -8,9 +8,9 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/quilt/quilt/api"
-	"github.com/quilt/quilt/api/client/getter"
-	"github.com/quilt/quilt/db"
+	"github.com/kelda/kelda/api"
+	"github.com/kelda/kelda/api/client/getter"
+	"github.com/kelda/kelda/db"
 
 	log "github.com/Sirupsen/logrus"
 )

--- a/tests/40-stop/check_stop.go
+++ b/tests/40-stop/check_stop.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/quilt/quilt/api"
-	"github.com/quilt/quilt/api/client/getter"
-	"github.com/quilt/quilt/minion/supervisor/images"
+	"github.com/kelda/kelda/api"
+	"github.com/kelda/kelda/api/client/getter"
+	"github.com/kelda/kelda/minion/supervisor/images"
 
 	log "github.com/Sirupsen/logrus"
 )

--- a/tests/61-duplicate-cluster/check_duplicate_cluster.go
+++ b/tests/61-duplicate-cluster/check_duplicate_cluster.go
@@ -7,8 +7,8 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 
-	"github.com/quilt/quilt/api"
-	"github.com/quilt/quilt/api/client/getter"
+	"github.com/kelda/kelda/api"
+	"github.com/kelda/kelda/api/client/getter"
 )
 
 func main() {

--- a/tests/build-dockerfile/check_custom_images.go
+++ b/tests/build-dockerfile/check_custom_images.go
@@ -6,9 +6,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/quilt/quilt/api"
-	"github.com/quilt/quilt/api/client/getter"
-	"github.com/quilt/quilt/db"
+	"github.com/kelda/kelda/api"
+	"github.com/kelda/kelda/api/client/getter"
+	"github.com/kelda/kelda/db"
 
 	log "github.com/Sirupsen/logrus"
 )

--- a/tests/elasticsearch/check_elasticsearch.go
+++ b/tests/elasticsearch/check_elasticsearch.go
@@ -10,9 +10,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/quilt/quilt/api"
-	"github.com/quilt/quilt/api/client/getter"
-	"github.com/quilt/quilt/db"
+	"github.com/kelda/kelda/api"
+	"github.com/kelda/kelda/api/client/getter"
+	"github.com/kelda/kelda/db"
 
 	log "github.com/Sirupsen/logrus"
 )

--- a/tests/etcd/check_etcd.go
+++ b/tests/etcd/check_etcd.go
@@ -5,9 +5,9 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/quilt/quilt/api"
-	"github.com/quilt/quilt/api/client/getter"
-	"github.com/quilt/quilt/db"
+	"github.com/kelda/kelda/api"
+	"github.com/kelda/kelda/api/client/getter"
+	"github.com/kelda/kelda/db"
 
 	log "github.com/Sirupsen/logrus"
 )

--- a/tests/inbound-public/check_inbound_public.go
+++ b/tests/inbound-public/check_inbound_public.go
@@ -5,9 +5,9 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/quilt/quilt/api"
-	"github.com/quilt/quilt/api/client/getter"
-	"github.com/quilt/quilt/db"
+	"github.com/kelda/kelda/api"
+	"github.com/kelda/kelda/api/client/getter"
+	"github.com/kelda/kelda/db"
 
 	log "github.com/Sirupsen/logrus"
 )

--- a/tests/outbound-public/check_outbound_public.go
+++ b/tests/outbound-public/check_outbound_public.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"os/exec"
 
-	"github.com/quilt/quilt/api"
-	"github.com/quilt/quilt/api/client/getter"
-	"github.com/quilt/quilt/db"
-	"github.com/quilt/quilt/stitch"
+	"github.com/kelda/kelda/api"
+	"github.com/kelda/kelda/api/client/getter"
+	"github.com/kelda/kelda/db"
+	"github.com/kelda/kelda/stitch"
 
 	log "github.com/Sirupsen/logrus"
 )


### PR DESCRIPTION
This patch makes the updates necessary for the tester to function
properly.  It's untested, so it may not be sufficient.