### PR TITLE
blueprint: Use Infrastructure constructor

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "./tester.js",
   "license": "MIT",
   "dependencies": {
-    "kelda": "0.x",
+    "kelda": ">=0.0.5 <1.0.0",
     "sshpk": "^1.13.1"
   },
   "devDependencies": {

--- a/testerRunnerExample.js
+++ b/testerRunnerExample.js
@@ -2,17 +2,13 @@
 // of all paramters to `tester.New`. It uses a floating IP to automatically
 // configure `jenkinsUrl`.
 
-const { createDeployment, Machine } = require('kelda');
+const { Infrastructure, Machine } = require('kelda');
 const Tester = require('./tester.js');
 
-const deployment = createDeployment();
 const baseMachine = new Machine({ provider: 'Amazon' });
 
-deployment.deploy(baseMachine.asMaster());
-
-const worker = baseMachine.asWorker();
+const worker = baseMachine.clone();
 worker.floatingIp = '8.8.8.8';
-deployment.deploy(worker);
 
 const tester = new Tester({
   awsAccessKey: 'accessKey',
@@ -31,4 +27,5 @@ const tester = new Tester({
   jenkinsUrl: `http://${worker.floatingIp}:8080`,
 });
 
-tester.deploy(deployment);
+const infra = new Infrastructure(baseMachine, worker);
+tester.deploy(infra);


### PR DESCRIPTION
This commit replaces the deprecated `createDeployment` function with the
new `Infrastructure` constructor.