### PR TITLE
jenkins: Make the release mirror available over HTTP

### DIFF
--- a/jenkins.js
+++ b/jenkins.js
@@ -83,7 +83,7 @@ function setupFiles(opts, scp) {
         // The ${KELDA_VERSION} string is not meant to be evaluated in the Javascript.
         // It should get expanded by Jenkins when the build runs.
         // eslint-disable-next-line no-template-curly-in-string
-        copyCommand: scp.getCommand('${KELDA_VERSION}.tar.gz', 'release.tar.gz', {
+        copyCommand: scp.getCommand('releases/${KELDA_VERSION}.tar.gz', 'release.tar.gz', {
           identityFile: releaserKeyPath,
           knownHostsFile: knownHostsPath,
         }),

--- a/scpServer/Dockerfile
+++ b/scpServer/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:jessie
 
 RUN apt-get update \
-  && apt-get install -y openssh-server rssh \
+  && apt-get install -y openssh-server rssh nginx \
   && rm -rf /etc/ssh/ssh_host_* \
   && mkdir /var/run/sshd && chmod 0755 /var/run/sshd \
   && echo "allowscp" >> /etc/rssh.conf

--- a/tester.js
+++ b/tester.js
@@ -68,8 +68,9 @@ class Tester {
     this.scp = new SCPServer(releaseUser, scpPort, userKeyPair, hostKeyPair);
     this.jenkins = jenkins.New(jenkinsOpts, this.scp);
 
-    this.scp.allowFrom(this.jenkins);
-    this.scp.allowFrom(kelda.publicInternet);
+    this.scp.allowSCPFrom(this.jenkins);
+    this.scp.allowSCPFrom(kelda.publicInternet);
+    this.scp.allowHTTPFrom(kelda.publicInternet);
   }
 
   deploy(deployment) {


### PR DESCRIPTION
This commit exposes the release mirror directory over HTTP so that
clients can easily download releases. It also moves the release
directory to a subdirectory so that the releaser user's entire home
directory is not served.