### PR TITLE
dockerfile: Build off of official LTS version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkinsci/jenkins:2.67
+FROM jenkins/jenkins:2.89.1
 
 USER root
 RUN apt-get update \


### PR DESCRIPTION
The `jenkinsci/jenkins` image has been deprecated in favor of
`jenkins/jenkins` (which is managed by the official Jenkins community).

This commit also changes the Jenkins version to the LTS version, which
is useful because each LTS version has its own update center for
plugins. Before, every time we reinstalled the plugins (i.e. we rebuilt
the Docker image), the latest versions of the plugins were installed
without consideration for whether they were compatible with the Jenkins
version.