### PR TITLE
jenkins: Allow viewing JUnit results in realtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ADD config/id_rsa /var/jenkins_home/.ssh/id_rsa
 
 RUN /usr/local/bin/install-plugins.sh golang ws-cleanup timestamper slack \
     test-results-analyzer claim nodejs parameterized-scheduler show-build-parameters \
-    groovy-postbuild
+    groovy-postbuild junit-realtime-test-reporter
 
 
 # XXX: We unset the Entrypoint so that blueprints can run arbitrary commands (such

--- a/config/jenkins/integration-tester.xml
+++ b/config/jenkins/integration-tester.xml
@@ -28,6 +28,7 @@
         </hudson.model.StringParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
+    <org.jenkinsci.plugins.junitrealtimetestreporter.PerJobConfiguration plugin="junit-realtime-test-reporter@0.5"/>
   </properties>
   <canRoam>true</canRoam>
   <disabled>false</disabled>
@@ -65,7 +66,7 @@ cd ${srcPath}/integration-tester
 go build .
 make tests
 
-./integration-tester --preserve-failed -testRoot=./tests -junitOut=${WORKSPACE}/report.xml</command>
+./integration-tester --preserve-failed -testRoot=./tests -junitOut=${WORKSPACE}/test-results</command>
     </hudson.tasks.Shell>
   </builders>
   <publishers>
@@ -90,7 +91,7 @@ manager.addShortText(&quot;Workers: ${manager.build.buildVariables.get(&apos;NUM
       <runForMatrixParent>false</runForMatrixParent>
     </org.jvnet.hudson.plugins.groovypostbuild.GroovyPostbuildRecorder>
     <hudson.tasks.junit.JUnitResultArchiver plugin="junit@1.20">
-      <testResults>report.xml</testResults>
+      <testResults>test-results/*.xml</testResults>
       <keepLongStdio>true</keepLongStdio>
       <healthScaleFactor>1.0</healthScaleFactor>
       <allowEmptyResults>false</allowEmptyResults>


### PR DESCRIPTION
Before, we could only see the test output after all the tests had
completed. Furthermore, if a build was cancelled, all the test results
were lost, even for the tests that had already completed.

This commit updates the integration tester config to use the new
integration tester flag for generating individual test reports, and
sets up the junit-realtime-test-reporter plugin.

This change depends on the integration-tester PR in the main Kelda
response(https://github.com/kelda/kelda/pull/1330). Once that PR is merged,
this PR will also need to be merged, and our Jenkins deployment will need to be
restarted with the new blueprint.