### PR TITLE
integration-tester: Use Groovy script to post results to Slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ on the Google provider.
 machines on the Google provider.
 - `testingNamespacePrefix`: The prefix for the namespace used by the test daemon.
 - `slackChannel`: The Slack channel where build results will be posted.
-- `slackTeam`: The Slack team in which `slackChannel` is located.
-- `slackToken`: The token used for posting to `slackChannel`.
+- `slackWebhook`: The Slack webhook used to post the build results. This can be
+- generated in the Slack workspace settings. For example, the Kelda Slack
+webhook was generated here https://kelda.slack.com/apps/A0F7XDUAZ-incoming-webhooks.
 
 The optional argments are:
 - `passwordHash`: A Jenkins-compatible hash of the desired password for the `admin` user.

--- a/config/jenkins/integration-tester.xml
+++ b/config/jenkins/integration-tester.xml
@@ -80,11 +80,85 @@ make tests
     </hudson.tasks.ArtifactArchiver>
     <org.jvnet.hudson.plugins.groovypostbuild.GroovyPostbuildRecorder plugin="groovy-postbuild@2.3.1">
       <script plugin="script-security@1.27">
-        <script>
-manager.addShortText(&quot;Version: ${manager.build.buildVariables.get(&apos;KELDA_VERSION&apos;)}&quot;)
-manager.addShortText(&quot;Provider: ${manager.build.buildVariables.get(&apos;PROVIDER&apos;)}&quot;)
-manager.addShortText(&quot;Workers: ${manager.build.buildVariables.get(&apos;NUMBER_WORKERS&apos;)}&quot;)
-        </script>
+            <script><![CDATA[import groovy.json.JsonOutput
+import hudson.tasks.test.AbstractTestResultAction
+import hudson.tasks.junit.CaseResult
+import hudson.tasks.junit.TestResult
+
+def notifySlack(channel, attachments) {
+    def slackURL = manager.getEnvVariable('SLACK_WEBHOOK')
+    def jenkinsIcon = 'https://wiki.jenkins-ci.org/download/attachments/2916393/logo.png'
+
+    def payload = JsonOutput.toJson([
+        channel: channel,
+        username: 'jenkins',
+        icon_url: jenkinsIcon,
+        attachments: attachments,
+    ])
+
+    ['curl', '-X', 'POST', '-H', 'Content-type: application/json',
+        '--data', payload, slackURL].execute()
+}
+
+// Make build parameters visible in the list of past jobs.
+def version = manager.build.buildVariables.get('KELDA_VERSION')
+def provider = manager.build.buildVariables.get('PROVIDER')
+def nWorkers = manager.build.buildVariables.get('NUMBER_WORKERS')
+manager.addShortText("Version: ${version}")
+manager.addShortText("Provider: ${provider}")
+manager.addShortText("Workers: ${nWorkers}")
+
+// Post the build result to Slack.
+def testResultAction = manager.build.getAction(AbstractTestResultAction.class)
+def numTotal = testResultAction.getTotalCount()
+def numFailed = testResultAction.getFailCount()
+def numSkipped = testResultAction.getSkipCount()
+def numPassed = numTotal - numFailed - numSkipped
+
+def message = "Passed: ${numPassed}, Failed: ${numFailed}, Skipped: ${numSkipped}"
+def color = 'good'
+if (numTotal == 0) {
+    color = 'warning'
+} else if (numFailed != 0) {
+    message += '\n<!channel> Some tests failed.'
+    color = 'danger'
+}
+
+def buildNumber = manager.getEnvVariable('BUILD_NUMBER')
+def buildURL = manager.getEnvVariable('BUILD_URL')
+def attachments = [
+    [
+        title: "#${buildNumber} - ${provider} | Version ${version} | ${nWorkers} Workers",
+        title_link: "${buildURL}",
+        text: message,
+        color: color,
+    ],
+]
+
+def gitRepoPath = manager.build.getWorkspace().child('gohome/src/github.com/kelda/kelda').toURI()
+def gitCommit = ['git', 'log', '-1', '--pretty=%an | %s'].execute(null, new File(gitRepoPath)).text
+attachments << [
+    title: 'Git Commit',
+    text: gitCommit,
+    color: color,
+]
+
+if (numFailed > 0) {
+    // We have to use getResult() and cast the test result because testResultAction.getFailedTests()
+    // is not defined by the junit-realtime-test-reporter plugin.
+    def testResult = (TestResult) testResultAction.getResult()
+    def failedTestsStr = ''
+    for (CaseResult cr : testResult.getFailedTests()) {
+        failedTestsStr += "<${manager.build.getAbsoluteUrl()}/testReport/${cr.getUrl()}|${cr.getName()}> after ${cr.getDurationString()}\n"
+    }
+    attachments << [
+        title: 'Failed Tests',
+        text: failedTestsStr,
+        color: color,
+    ]
+}
+
+notifySlack(manager.getEnvVariable('SLACK_CHANNEL'), attachments)]]></script>
         <sandbox>false</sandbox>
       </script>
       <behavior>0</behavior>
@@ -97,28 +171,6 @@ manager.addShortText(&quot;Workers: ${manager.build.buildVariables.get(&apos;NUM
       <allowEmptyResults>false</allowEmptyResults>
     </hudson.tasks.junit.JUnitResultArchiver>
     <hudson.plugins.claim.ClaimPublisher plugin="claim@2.9"/>
-    <jenkins.plugins.slack.SlackNotifier plugin="slack@2.2">
-      <baseUrl></baseUrl>
-      <teamDomain>{{slackTeam}}</teamDomain>
-      <authToken>{{slackToken}}</authToken>
-      <authTokenCredentialId></authTokenCredentialId>
-      <botUser>false</botUser>
-      <room>{{slackChannel}}</room>
-      <startNotification>false</startNotification>
-      <notifySuccess>true</notifySuccess>
-      <notifyAborted>true</notifyAborted>
-      <notifyNotBuilt>true</notifyNotBuilt>
-      <notifyUnstable>true</notifyUnstable>
-      <notifyRegression>true</notifyRegression>
-      <notifyFailure>true</notifyFailure>
-      <notifyBackToNormal>true</notifyBackToNormal>
-      <notifyRepeatedFailure>true</notifyRepeatedFailure>
-      <includeTestSummary>true</includeTestSummary>
-      <includeFailedTests>true</includeFailedTests>
-      <commitInfoChoice>AUTHORS_AND_TITLES</commitInfoChoice>
-      <includeCustomMessage>false</includeCustomMessage>
-      <customMessage></customMessage>
-    </jenkins.plugins.slack.SlackNotifier>
   </publishers>
   <buildWrappers>
     <hudson.plugins.ws__cleanup.PreBuildCleanup plugin="ws-cleanup@0.32">

--- a/config/jenkins/scriptApproval.xml
+++ b/config/jenkins/scriptApproval.xml
@@ -9,7 +9,7 @@ resulting file at /var/jenkins_home/scriptApproval.xml.
 -->
 <scriptApproval plugin="script-security@1.27">
   <approvedScriptHashes>
-    <string>ea96c75ecf695393d49a2d29e96610432e3067b2</string>
+    <string>0b9bc74f6199692ce7996b808f6a97ab27fcaf28</string>
   </approvedScriptHashes>
   <approvedSignatures/>
   <aclApprovedSignatures/>

--- a/jenkins.js
+++ b/jenkins.js
@@ -80,9 +80,6 @@ function setupFiles(opts, scp) {
     `${scp.getHostname()} ${scp.hostKeyPair.pub}`));
 
   const templateOpts = {
-    slackTeam: opts.slackTeam,
-    slackToken: opts.slackToken,
-    slackChannel: opts.slackChannel,
     // The ${KELDA_VERSION} string is not meant to be evaluated in the Javascript.
     // It should get expanded by Jenkins when the build runs.
     // eslint-disable-next-line no-template-curly-in-string
@@ -137,7 +134,7 @@ exports.New = function New(opts, scp) {
     'digitalOceanKey',
     'gceProjectID', 'gcePrivateKey', 'gceClientEmail',
     'testingNamespacePrefix',
-    'slackTeam', 'slackChannel', 'slackToken']);
+    'slackWebhook', 'slackChannel']);
 
   const jenkins = new Container('jenkins', 'keldaio/tester', {
     command: ['/bin/bash', '-c',
@@ -152,6 +149,8 @@ exports.New = function New(opts, scp) {
   jenkins.setEnv('AWS_S3_ACCESS_KEY_ID', opts.awsS3AccessKey);
   jenkins.setEnv('AWS_S3_SECRET_ACCESS_KEY', opts.awsS3SecretAccessKey);
   jenkins.setEnv('TESTING_NAMESPACE_PREFIX', opts.testingNamespacePrefix);
+  jenkins.setEnv('SLACK_WEBHOOK', opts.slackWebhook);
+  jenkins.setEnv('SLACK_CHANNEL', opts.slackChannel);
   jenkins.setEnv('TZ', '/usr/share/zoneinfo/America/Los_Angeles');
 
   const files = setupFiles(opts, scp);

--- a/testerRunnerExample.js
+++ b/testerRunnerExample.js
@@ -26,9 +26,8 @@ const tester = new Tester({
   gceClientEmail: 'email',
   digitalOceanKey: 'key',
   testingNamespacePrefix: 'integration-tester',
-  slackTeam: 'kelda-dev',
   slackChannel: '#testing',
-  slackToken: 'secret',
+  slackWebhook: 'https://hooks.slack.com/services/...',
   // Because of a bug with the `applyTemplate` function, dollar sign literals
   // (`$`) need to be replaced with `$$`.
   passwordHash: '#jbcrypt:$$2a$$10$$Jcwink6XXoUIp3Ieh.1QR.Mx5idVA7QNLHNcF2jQWhoCA96y5k/jS',


### PR DESCRIPTION
Before this commit, we used a Jenkins plugin to post the build results
to Slack; however, the plugin does not seem to have much activity
anymore, and it lacks some desirable features. This commit removes the
plugin in favor of a Groovy script that directly posts the build results
to Slack. The Groovy script implementation also includes several
enhancements:
- It includes the latest Git commit in the post.
- It includes the Kelda version and number of workers in the post.
- It links failed tests to their output page.
- It pings @channel when tests fail, allowing people to mute the
channel, and only receive notifications when tests fail.