### PR TITLE
jenkins: Run tests every two hours

### DIFF
--- a/config/jenkins/integration-tester.xml
+++ b/config/jenkins/integration-tester.xml
@@ -37,7 +37,7 @@
   <triggers>
     <org.jenkinsci.plugins.parameterizedscheduler.ParameterizedTimerTrigger plugin="parameterized-scheduler@0.4">
       <spec></spec>
-      <parameterizedSpecification>0 * * * *</parameterizedSpecification>
+      <parameterizedSpecification>0 */2 * * *</parameterizedSpecification>
     </org.jenkinsci.plugins.parameterizedscheduler.ParameterizedTimerTrigger>
   </triggers>
   <concurrentBuild>false</concurrentBuild>


### PR DESCRIPTION
Because the tests take about an hour and a half to finish, if the tests
run every hour there is no chance to debug after failed tests.