### PR TITLE
blueprint: Remove use of deprecated functions

### DIFF
--- a/jenkins.js
+++ b/jenkins.js
@@ -136,7 +136,9 @@ exports.New = function New(opts, scp) {
     'testingNamespacePrefix',
     'slackWebhook', 'slackChannel']);
 
-  const jenkins = new Container('jenkins', 'keldaio/tester', {
+  const jenkins = new Container({
+    name: 'jenkins',
+    image: 'keldaio/tester',
     command: ['/bin/bash', '-c',
       `cp -r ${jenkinsStagingDir}. /var/jenkins_home;` +
       `chmod 0600 ${releaserKeyPath};` +

--- a/jenkins.js
+++ b/jenkins.js
@@ -144,16 +144,16 @@ exports.New = function New(opts, scp) {
       `chmod 0600 ${releaserKeyPath};` +
             '/bin/tini -s -- /usr/local/bin/jenkins.sh'],
   });
-  jenkins.setEnv('AWS_ACCESS_KEY', opts.awsAccessKey);
-  jenkins.setEnv('AWS_SECRET_ACCESS_KEY', opts.awsSecretAccessKey);
+  jenkins.env.AWS_ACCESS_KEY = opts.awsAccessKey;
+  jenkins.env.AWS_SECRET_ACCESS_KEY = opts.awsSecretAccessKey;
   // Set different environment variables with the keys that have access only to
   // S3.
-  jenkins.setEnv('AWS_S3_ACCESS_KEY_ID', opts.awsS3AccessKey);
-  jenkins.setEnv('AWS_S3_SECRET_ACCESS_KEY', opts.awsS3SecretAccessKey);
-  jenkins.setEnv('TESTING_NAMESPACE_PREFIX', opts.testingNamespacePrefix);
-  jenkins.setEnv('SLACK_WEBHOOK', opts.slackWebhook);
-  jenkins.setEnv('SLACK_CHANNEL', opts.slackChannel);
-  jenkins.setEnv('TZ', '/usr/share/zoneinfo/America/Los_Angeles');
+  jenkins.env.AWS_S3_ACCESS_KEY_ID = opts.awsS3AccessKey;
+  jenkins.env.AWS_S3_SECRET_ACCESS_KEY = opts.awsS3SecretAccessKey;
+  jenkins.env.TESTING_NAMESPACE_PREFIX = opts.testingNamespacePrefix;
+  jenkins.env.SLACK_WEBHOOK = opts.slackWebhook;
+  jenkins.env.SLACK_CHANNEL = opts.slackChannel;
+  jenkins.env.TZ = '/usr/share/zoneinfo/America/Los_Angeles';
 
   const files = setupFiles(opts, scp);
   files.forEach((f) => {

--- a/scpServer/index.js
+++ b/scpServer/index.js
@@ -18,15 +18,19 @@ class SCPServer extends kelda.Container {
    * @return {void}
    */
   constructor(user, port, userKeyPair, hostKeyPair) {
-    const image = new kelda.Image('scp-server',
-      fs.readFileSync(path.join(__dirname, 'Dockerfile'), { encoding: 'utf8' }));
+    const image = new kelda.Image({
+      name: 'scp-server',
+      dockerfile: fs.readFileSync(path.join(__dirname, 'Dockerfile'), { encoding: 'utf8' }),
+    });
     const hostKeyType = sshpk.parsePrivateKey(hostKeyPair.priv).type;
     const hostKeyPath = `/etc/ssh/ssh_host_${hostKeyType}_key`;
     const nginxConf = `server {
       root /home/${user}/releases;
       location / { autoindex on; }
     }`;
-    super('scp', image, {
+    super({
+      name: 'scp',
+      image,
       command: ['bash', '-c',
         // XXX: We need to chmod the host's private key because
         // filepathToContent doesn't support setting file modes.

--- a/testerRunnerExample.js
+++ b/testerRunnerExample.js
@@ -34,5 +34,5 @@ const tester = new Tester({
   jenkinsUrl: `http://${worker.floatingIp}:8080`,
 });
 
-const infra = new Infrastructure(baseMachine, worker);
+const infra = new Infrastructure({ masters: baseMachine, workers: worker });
 tester.deploy(infra);


### PR DESCRIPTION
The build will fail until the next release of Kelda (0.10.0). This should not be merged until then.